### PR TITLE
Use single quotes for content

### DIFF
--- a/lib/puppet/provider/nfsfile/ruby.rb
+++ b/lib/puppet/provider/nfsfile/ruby.rb
@@ -26,7 +26,7 @@ Puppet::Type.type(:nfsfile).provide(:ruby) do
 
   def write_file(owner, content, path)
     content = content.gsub(/\\/, '\\\\').gsub(/"/, '\\"')
-    runuser(['-l', owner, '-c', "echo -n \"#{content}\" > #{path}"])
+    runuser(['-l', owner, '-c', "echo -n '#{content}' > #{path}"])
   end
 
   def exists?


### PR DESCRIPTION
I am encountering a bug where bash variables are evaluated while a file content is being placed into the file.

For example, if I wanted a file to have the literal contents `export PATH="/mypath/:$PATH"`

It instead creates a file with
`export PATH="/mypath/:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin"

I am hoping that by using single quotes we can prevent the file content from being evlauated during placement.